### PR TITLE
Update midiconnect.py for python3

### DIFF
--- a/midiconnect.py
+++ b/midiconnect.py
@@ -4,7 +4,7 @@ import re, os
 from subprocess import Popen, PIPE
 
 def os_system(command):
-    process = Popen(command, stdout=PIPE, shell=True)
+    process = Popen(command, stdout=PIPE, shell=True, encoding='utf8')
     while True:
         line = process.stdout.readline()
         if not line:


### PR DESCRIPTION
stops string / binary error in python3